### PR TITLE
Search by video

### DIFF
--- a/embed.py
+++ b/embed.py
@@ -1,6 +1,6 @@
 import os
 from twelvelabs import TwelveLabs
-from typing import List
+from typing import List, Optional, Literal
 from twelvelabs.models.embed import EmbeddingsTask, SegmentEmbedding
 from dotenv import load_dotenv
 
@@ -23,14 +23,19 @@ def print_segments(segments: List[SegmentEmbedding], max_elements: int = 5):
             print(f"  embeddings: {segment.embeddings_float[:max_elements]}")
 
 
-def extract_video_features(video_filepath: str, DEBUG=False):
+def extract_video_features(
+    filepath: Optional[str] = None,
+    url: Optional[str] = None,
+    DEBUG=False,
+):
     # 1. Initialize the client
     client = TwelveLabs(api_key=TWELVELABS_API_KEY)
 
     # 2. Upload a video
     task = client.embed.task.create(
         model_name="Marengo-retrieval-2.7",
-        video_file=video_filepath,
+        video_file=filepath,
+        video_url=url,
         # video_clip_length=5,
         # video_start_offset_sec=30,
         # video_end_offset_sec=60,
@@ -55,6 +60,15 @@ def extract_video_features(video_filepath: str, DEBUG=False):
         raise Exception("Embedding failed")
 
     return task.video_embedding.segments
+
+
+def extract_video_embeddings(
+    filepath: Optional[str] = None,
+    url: Optional[str] = None,
+    DEBUG=False,
+):
+    segments = extract_video_features(filepath, url, DEBUG)
+    return [segment.embeddings_float for segment in segments]
 
 
 def extract_text_features(input: str):

--- a/embed.py
+++ b/embed.py
@@ -1,6 +1,6 @@
 import os
 from twelvelabs import TwelveLabs
-from typing import List, Optional, Literal
+from typing import List, Optional
 from twelvelabs.models.embed import EmbeddingsTask, SegmentEmbedding
 from dotenv import load_dotenv
 

--- a/main.py
+++ b/main.py
@@ -4,46 +4,16 @@ from flask import (
     request,
 )
 import os
-import embed
-import vector_db
+from search_routes import search_bp
 
 
 app = Flask(__name__)
+app.register_blueprint(search_bp)
 
 
 @app.route("/health")
 def health():
     return "", 200
-
-
-@app.route("/search", methods=("POST",))
-def search():
-    """
-    Expects a JSON body with the following properties:
-        query_text: string,
-        page_limit: integer (optional)
-        min_similarity: float (optional)
-    """
-    request_data = request.get_json()
-
-    if not request_data:
-        return jsonify(
-            {
-                "error": "Invalid request body - must be a JSON object with 'query_text' parameter."
-            }
-        ), 400
-
-    query_text = request_data.get("query_text")
-    page_limit = request_data.get("page_limit")
-    min_similarity = request_data.get("min_similarity")
-    text_embedding = embed.extract_text_features(query_text)
-
-    results = vector_db.find_similar(text_embedding, page_limit, min_similarity)
-
-    data = {
-        "data": results,
-    }
-    return jsonify(data)
 
 
 # Route for video ingest tasks

--- a/search_routes.py
+++ b/search_routes.py
@@ -9,7 +9,7 @@ search_bp = Blueprint("search", __name__)
 @search_bp.route("/search", methods=("POST",))
 def search():
     """
-    Expects a JSON body with the following properties:
+    Expects multipart/form-data with the following fields:
         query_text: string (optional)
         query_media_type: "image" | "video" | "audio" (optional)
         query_media_url: string (optional)
@@ -17,27 +17,31 @@ def search():
         page_limit: integer (optional)
         min_similarity: float (optional)
     """
-    request_data = request.get_json()
+    query_text = request.form.get("query_text")
+    query_media_type = request.form.get("query_media_type")
+    page_limit = request.form.get("page_limit", vector_db.DEFAULT_PAGE_LIMIT)
+    min_similarity = request.form.get(
+        "min_similarity", vector_db.DEFAULT_MIN_SIMILARITY
+    )
 
-    if not request_data:
-        return jsonify({"error": "Invalid request body - must be a JSON object."}), 400
+    # Convert string parameters to appropriate types
+    page_limit = int(page_limit)
+    min_similarity = float(min_similarity)
 
-    query_text = request_data.get("query_text")
-    query_media_type = request_data.get("query_media_type")
-    page_limit = request_data.get("page_limit")
-    min_similarity = request_data.get("min_similarity")
     # Currently only supporting one embedding source
     # TODO: should be able to search with multiple embeddings (text + some media)
 
     if query_media_type:
-        query_media_url = request_data.get("query_media_url")
-        query_media_file = request_data.get("query_media_file")
+        query_media_url = request.form.get("query_media_url")
+        query_media_file = request.files.get("query_media_file")
         if query_media_type == "video":
             if query_media_url:
                 embeddings = embed.extract_video_embeddings(url=query_media_url)
             elif query_media_file:
-                with tempfile.NamedTemporaryFile(delete=False) as f:
-                    embeddings = embed.extract_video_embeddings(filepath=f.filepath)
+                # Save the uploaded file to a temporary location
+                with tempfile.NamedTemporaryFile() as temp_file:
+                    query_media_file.save(temp_file.name)
+                    embeddings = embed.extract_video_embeddings(filepath=temp_file.name)
             else:
                 return jsonify(
                     {
@@ -45,10 +49,11 @@ def search():
                     }
                 ), 400
 
-    else:
-        embeddings = [embed.extract_text_features(query_text)]
+        results = vector_db.find_similar_batch(embeddings, page_limit, min_similarity)
 
-    results = vector_db.find_similar_batch(embeddings, page_limit, min_similarity)
+    else:
+        embedding = embed.extract_text_features(query_text)
+        results = vector_db.find_similar(embedding)
 
     data = {
         "data": results,

--- a/search_routes.py
+++ b/search_routes.py
@@ -1,0 +1,56 @@
+from flask import Blueprint, jsonify, request
+import tempfile
+import embed
+import vector_db
+
+search_bp = Blueprint("search", __name__)
+
+
+@search_bp.route("/search", methods=("POST",))
+def search():
+    """
+    Expects a JSON body with the following properties:
+        query_text: string (optional)
+        query_media_type: "image" | "video" | "audio" (optional)
+        query_media_url: string (optional)
+        query_media_file: file (optional)
+        page_limit: integer (optional)
+        min_similarity: float (optional)
+    """
+    request_data = request.get_json()
+
+    if not request_data:
+        return jsonify({"error": "Invalid request body - must be a JSON object."}), 400
+
+    query_text = request_data.get("query_text")
+    query_media_type = request_data.get("query_media_type")
+    page_limit = request_data.get("page_limit")
+    min_similarity = request_data.get("min_similarity")
+    # Currently only supporting one embedding source
+    # TODO: should be able to search with multiple embeddings (text + some media)
+
+    if query_media_type:
+        query_media_url = request_data.get("query_media_url")
+        query_media_file = request_data.get("query_media_file")
+        if query_media_type == "video":
+            if query_media_url:
+                embeddings = embed.extract_video_embeddings(url=query_media_url)
+            elif query_media_file:
+                with tempfile.NamedTemporaryFile(delete=False) as f:
+                    embeddings = embed.extract_video_embeddings(filepath=f.filepath)
+            else:
+                return jsonify(
+                    {
+                        "error": "Invalid request body - If `query_media_type` is specified, request body must contain `query_media_url` or `query_media_file`."
+                    }
+                ), 400
+
+    else:
+        embeddings = [embed.extract_text_features(query_text)]
+
+    results = vector_db.find_similar_batch(embeddings, page_limit, min_similarity)
+
+    data = {
+        "data": results,
+    }
+    return jsonify(data)

--- a/search_routes.py
+++ b/search_routes.py
@@ -34,6 +34,7 @@ def search():
     if query_media_type:
         query_media_url = request.form.get("query_media_url")
         query_media_file = request.files.get("query_media_file")
+        embeddings = None
         if query_media_type == "video":
             if query_media_url:
                 embeddings = embed.extract_video_embeddings(url=query_media_url)
@@ -52,6 +53,13 @@ def search():
         results = vector_db.find_similar_batch(embeddings, page_limit, min_similarity)
 
     else:
+        if not query_text:
+            return jsonify(
+                {
+                    "error": "Invalid request body - If `query_media_type` is not specified, request body must contain `query_text`."
+                }
+            ), 400
+
         embedding = embed.extract_text_features(query_text)
         results = vector_db.find_similar(embedding)
 

--- a/vector_db.py
+++ b/vector_db.py
@@ -17,6 +17,10 @@ DB_PARAMS = {
     "database": DATABASE_NAME,
 }
 
+# Default search parameters
+DEFAULT_PAGE_LIMIT = 5
+DEFAULT_MIN_SIMILARITY = 0.2
+
 
 def get_connection():
     return psycopg2.connect(**DB_PARAMS)
@@ -76,7 +80,9 @@ def store(video_filepath, embedding_type, start_offset, end_offset, embedding):
         conn.close()
 
 
-def find_similar(embedding, page_limit=5, min_similarity=0.3) -> list[dict[str, Any]]:
+def find_similar(
+    embedding, page_limit=DEFAULT_PAGE_LIMIT, min_similarity=DEFAULT_MIN_SIMILARITY
+) -> list[dict[str, Any]]:
     try:
         # Connect to the database
         conn = get_connection()
@@ -103,4 +109,53 @@ def find_similar(embedding, page_limit=5, min_similarity=0.3) -> list[dict[str, 
 
     except Exception as e:
         print(f"Error searching database: {e}")
+        raise e
+
+
+def find_similar_batch(
+    embeddings, page_limit=DEFAULT_PAGE_LIMIT, min_similarity=DEFAULT_MIN_SIMILARITY
+) -> list[dict[str, Any]]:
+    try:
+        # Connect to the database
+        conn = get_connection()
+
+        # Create a UNION query for multiple embeddings
+        query_parts = []
+        params = []
+
+        for i, embedding in enumerate(embeddings):
+            query_parts.append(f"""
+                SELECT
+                    id,
+                    source,
+                    type,
+                    start_offset,
+                    end_offset,
+                    1 - (embedding <=> %s::vector) AS similarity,
+                    {i} AS query_index
+                FROM video_embeddings
+                WHERE (1 - (embedding <=> %s::vector)) > %s
+            """)
+            params.extend([embedding, embedding, min_similarity])
+
+        # Combine all queries with UNION and order by similarity
+        full_query = f"""
+            WITH combined_results AS (
+                {" UNION ALL ".join(query_parts)}
+            )
+            SELECT * FROM combined_results
+            ORDER BY similarity DESC
+            LIMIT %s;
+        """
+        params.append(page_limit)
+
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(full_query, params)
+            results = cur.fetchall()
+
+        conn.close()
+        return results
+
+    except Exception as e:
+        print(f"Error searching database with batch: {e}")
         raise e


### PR DESCRIPTION
- Changed the route to accept multi-part/form-data to allow for file upload.
- The method to search with multiple vectors is probably not optimal right now.
- Searching with a video that has empty audio matches arbitrary audio embeddings very high.
  - Seems like this is why TwelveLabs has visual/audio search options in their search API