### PR TITLE
Search full video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,9 +182,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
@@ -207,3 +207,5 @@ marimo/_lsp/
 __marimo__/
 
 **/.DS_Store
+
+credentials.json

--- a/app/routes/search.py
+++ b/app/routes/search.py
@@ -66,14 +66,14 @@ def create_search_bp(embed_service: EmbedService, vector_db_service: VectorDBSer
 
             elif query_media_type == "video":
                 if query_media_url:
-                    embeddings = embed_service.extract_video_embeddings(
+                    embeddings = embed_service.extract_video_embedding(
                         url=query_media_url
                     )
                 elif query_media_file:
                     # Save the uploaded file to a temporary location
                     with tempfile.NamedTemporaryFile() as temp_file:
                         query_media_file.save(temp_file.name)
-                        embeddings = embed_service.extract_video_embeddings(
+                        embeddings = embed_service.extract_video_embedding(
                             filepath=temp_file.name
                         )
                 else:

--- a/app/routes/search.py
+++ b/app/routes/search.py
@@ -42,12 +42,12 @@ def create_search_bp(embed_service: EmbedService, vector_db_service: VectorDBSer
             embeddings = None
             if query_media_type == "image":
                 if query_media_url:
-                    embedding = embed_service.extract_image_embeddings(
+                    embedding = embed_service.extract_image_embedding(
                         url=query_media_url
                     )
 
                 elif query_media_file:
-                    embedding = embed_service.extract_image_embeddings(
+                    embedding = embed_service.extract_image_embedding(
                         file=query_media_file
                     )
                 else:
@@ -101,7 +101,7 @@ def create_search_bp(embed_service: EmbedService, vector_db_service: VectorDBSer
                     400,
                 )
 
-            embedding = embed_service.extract_text_embeddings(query_text)
+            embedding = embed_service.extract_text_embedding(query_text)
             results = vector_db_service.find_similar(embedding)
 
         data = {

--- a/app/routes/search.py
+++ b/app/routes/search.py
@@ -51,11 +51,14 @@ def create_search_bp(embed_service: EmbedService, vector_db_service: VectorDBSer
                         file=query_media_file
                     )
                 else:
-                    return jsonify(
-                        {
-                            "error": "Invalid request body - If `query_media_type` is specified, request body must contain `query_media_url` or `query_media_file`."
-                        }
-                    ), 400
+                    return (
+                        jsonify(
+                            {
+                                "error": "Invalid request body - If `query_media_type` is specified, request body must contain `query_media_url` or `query_media_file`."
+                            }
+                        ),
+                        400,
+                    )
 
                 results = vector_db_service.find_similar(
                     embedding, page_limit, min_similarity
@@ -74,11 +77,14 @@ def create_search_bp(embed_service: EmbedService, vector_db_service: VectorDBSer
                             filepath=temp_file.name
                         )
                 else:
-                    return jsonify(
-                        {
-                            "error": "Invalid request body - If `query_media_type` is specified, request body must contain `query_media_url` or `query_media_file`."
-                        }
-                    ), 400
+                    return (
+                        jsonify(
+                            {
+                                "error": "Invalid request body - If `query_media_type` is specified, request body must contain `query_media_url` or `query_media_file`."
+                            }
+                        ),
+                        400,
+                    )
 
                 results = vector_db_service.find_similar_batch(
                     embeddings, page_limit, min_similarity
@@ -86,11 +92,14 @@ def create_search_bp(embed_service: EmbedService, vector_db_service: VectorDBSer
 
         else:
             if not query_text:
-                return jsonify(
-                    {
-                        "error": "Invalid request body - If `query_media_type` is not specified, request body must contain `query_text`."
-                    }
-                ), 400
+                return (
+                    jsonify(
+                        {
+                            "error": "Invalid request body - If `query_media_type` is not specified, request body must contain `query_text`."
+                        }
+                    ),
+                    400,
+                )
 
             embedding = embed_service.extract_text_embeddings(query_text)
             results = vector_db_service.find_similar(embedding)

--- a/app/services/embed_service.py
+++ b/app/services/embed_service.py
@@ -56,20 +56,6 @@ class EmbedService:
         # TODO: Formalise this return type - right now it is arbitrary (based on Marengo API)
         return task.video_embedding.segments
 
-    def extract_video_embeddings(
-        self,
-        filepath: Optional[str] = None,
-        url: Optional[str] = None,
-        debug=False,
-    ):
-        segments = self.extract_video_features(filepath, url, debug)
-        print(segments)
-        return [
-            segment.embeddings_float
-            for segment in segments
-            if segment.embedding_scope == "clip"
-        ]
-
     def extract_video_embedding(
         self,
         filepath: Optional[str] = None,

--- a/app/services/embed_service.py
+++ b/app/services/embed_service.py
@@ -70,7 +70,7 @@ class EmbedService:
             if segment.embedding_scope == "video"
         ]
 
-    def extract_image_embeddings(
+    def extract_image_embedding(
         self,
         file: Optional[BinaryIO] = None,
         url: Optional[str] = None,
@@ -89,7 +89,7 @@ class EmbedService:
         if res.image_embedding is not None and res.image_embedding.segments is not None:
             return res.image_embedding.segments[0].embeddings_float
 
-    def extract_text_embeddings(self, input_text: str):
+    def extract_text_embedding(self, input_text: str):
         res = self.client.embed.create(
             model_name="Marengo-retrieval-2.7", text_truncate="start", text=input_text
         )

--- a/app/services/embed_service.py
+++ b/app/services/embed_service.py
@@ -37,7 +37,7 @@ class EmbedService:
             video_clip_length=clip_length,
             video_start_offset_sec=start_offset,
             video_end_offset_sec=end_offset,
-            video_embedding_scopes=["clip"],
+            video_embedding_scopes=["clip", "video"],
         )
         if self.config.DEBUG:
             print(
@@ -64,6 +64,20 @@ class EmbedService:
     ):
         segments = self.extract_video_features(filepath, url, debug)
         return [segment.embeddings_float for segment in segments]
+
+    def extract_video_embedding(
+        self,
+        filepath: Optional[str] = None,
+        url: Optional[str] = None,
+        debug=False,
+    ):
+        segments = self.extract_video_features(filepath, url, debug)
+
+        return [
+            segment.embeddings_float
+            for segment in segments
+            if segment.embedding_scope == "video"
+        ]
 
     def extract_image_embeddings(
         self,

--- a/app/services/embed_service.py
+++ b/app/services/embed_service.py
@@ -63,7 +63,12 @@ class EmbedService:
         debug=False,
     ):
         segments = self.extract_video_features(filepath, url, debug)
-        return [segment.embeddings_float for segment in segments]
+        print(segments)
+        return [
+            segment.embeddings_float
+            for segment in segments
+            if segment.embedding_scope == "clip"
+        ]
 
     def extract_video_embedding(
         self,

--- a/cli.py
+++ b/cli.py
@@ -21,7 +21,8 @@ def print_hint():
 
 
 def print_help():
-    help_doc = HTML("""
+    help_doc = HTML(
+        """
 Commands:
 <b><orange>/help</orange></b>           : Display this document
 <b><orange>/exit</orange></b>           : Exit the session
@@ -30,7 +31,8 @@ Commands:
 <b><orange>/add_file</orange></b>       : Add a video file by filepath
 <b><orange>/add_youtube</orange></b>    : Add a video file by youtube link
 <b><orange>/search_text</orange></b>    : Search with a text query
-""")
+"""
+    )
     print_formatted_text(help_doc)
 
 

--- a/cli.py
+++ b/cli.py
@@ -156,7 +156,7 @@ def add_file(
 def search_text(
     query, embed_service: EmbedService, vector_db_service: VectorDBService, DEBUG=False
 ):
-    text_embedding = embed_service.extract_text_embeddings(query)
+    text_embedding = embed_service.extract_text_embedding(query)
     if DEBUG and text_embedding is not None:
         print("text_embedding:", text_embedding)
 


### PR DESCRIPTION
- Updated the `extract_video_features` to have as `video_embedding_scopes` the whole video.
- Created a new function `extract_video_embedding` which returns the embedding of the whole video (`segment.embedding_scope == "video"`)
- Updated the `create_search_bp` function to use the new `extract_video_embedding` when searching by video.
- @dchae we are currently not storing the embedding scope in the database, do you think it could be useful in the future in the case that a user wants to search only by whole video and not by clip? Meaning that the user would like to get matches of whole videos and not sections of it?