### PR TITLE
feat: extracted filter to it's own json object

### DIFF
--- a/app/routes/search.py
+++ b/app/routes/search.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 
 from app.services.embed_service import EmbedService
@@ -18,8 +19,7 @@ def create_search_bp(embed_service: EmbedService, vector_db_service: VectorDBSer
             query_media_file: file (optional)
             page_limit: integer (optional)
             min_similarity: float (optional)
-            query_scope: "video" | "clip" (optional)
-            query_modality: "visual-text" | "audio"  (optional)
+            filter: JSON (optional)
         """
 
         query_text = request.form.get("query_text")
@@ -30,8 +30,10 @@ def create_search_bp(embed_service: EmbedService, vector_db_service: VectorDBSer
         min_similarity = request.form.get(
             "min_similarity", vector_db_service.default_min_similarity
         )
-        scope = request.form.get("query_scope")
-        modality = request.form.get("query_modality")
+        filter = request.form.get("filter")
+
+        if filter:
+            filter = json.loads(filter)
 
         # Convert string parameters to appropriate types
         page_limit = int(page_limit)
@@ -68,8 +70,7 @@ def create_search_bp(embed_service: EmbedService, vector_db_service: VectorDBSer
                     embedding,
                     page_limit=page_limit,
                     min_similarity=min_similarity,
-                    modality=modality,
-                    scope=scope,
+                    filter=filter,
                 )
 
             elif query_media_type == "video":
@@ -121,8 +122,7 @@ def create_search_bp(embed_service: EmbedService, vector_db_service: VectorDBSer
             embedding = embed_service.extract_text_embedding(query_text)
             results = vector_db_service.find_similar(
                 embedding,
-                scope=scope,
-                modality=modality,
+                filter=filter,
                 page_limit=page_limit,
                 min_similarity=min_similarity,
             )

--- a/app/services/vector_db_service.py
+++ b/app/services/vector_db_service.py
@@ -123,7 +123,11 @@ class VectorDBService:
         )
 
     def find_similar(
-        self, embedding, scope=None, modality=None, page_limit=None, min_similarity=None
+        self,
+        embedding,
+        filter,
+        page_limit=None,
+        min_similarity=None,
     ) -> list[dict[str, Any]]:
         page_limit = page_limit or self.default_page_limit
         min_similarity = min_similarity or self.default_min_similarity
@@ -156,12 +160,12 @@ class VectorDBService:
         )
         query_params.extend([embedding, embedding, min_similarity])
 
-        if scope:
+        if filter and "scope" in filter:
             query_parts.append(f"AND scope = %s")
-            query_params.append(scope)
-        if modality:
+            query_params.append(filter["scope"])
+        if filter and "modality" in filter:
             query_parts.append(f"AND modality = %s")
-            query_params.append(modality)
+            query_params.append(filter["modality"])
 
         query_parts.append("ORDER BY similarity DESC LIMIT %s")
         query_params.append(page_limit)


### PR DESCRIPTION
- Updated the search route to take an optional JSON object 'filter'
- The filter object is a list of K/V pairs that can be applied as search filters, the key corresponds to the column name in the data base and the value is the value being filtered.
- This currently works for scope and modality but more filters can be added